### PR TITLE
Explicitly link to std::filesystem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,10 +29,10 @@ add_library(parser ${PARSER_SRCS})
 target_link_libraries(parser ${Boost_LIBRARIES} Qt5::Core)
 
 add_executable(confgen ${configurationGeneration_SRCS})
-target_link_libraries(confgen parser Qt5::Core)
+target_link_libraries(confgen parser Qt5::Core stdc++fs)
 
 add_executable(qtobjgen ${QObjectGeneration_SRCS})
-target_link_libraries(qtobjgen parser Qt5::Core)
+target_link_libraries(qtobjgen parser Qt5::Core stdc++fs)
 
 enable_testing()
 add_subdirectory(test)


### PR DESCRIPTION
On older compilers this is not automatic:

[ 14%] Linking CXX executable qtobjgen
/usr/bin/ld: CMakeFiles/qtobjgen.dir/main.cpp.o: in function `main':
main.cpp:(.text+0x4d3): undefined reference to `std::filesystem::__cxx11::path::_M_split_cmpts()'
/usr/bin/ld: main.cpp:(.text+0x7d3): undefined reference to `std::filesystem::__cxx11::path::_M_split_cmpts()'
/usr/bin/ld: main.cpp:(.text+0x7e5): undefined reference to `std::filesystem::absolute(std::filesystem::__cxx11::path const&)'
/usr/bin/ld: main.cpp:(.text+0x9f6): undefined reference to `std::filesystem::__cxx11::path::_M_split_cmpts()'
/usr/bin/ld: main.cpp:(.text+0xa05): undefined reference to `std::filesystem::absolute(std::filesystem::__cxx11::path const&)'
clang: error: linker command failed with exit code 1 (use -v to see invocation)